### PR TITLE
Added encoding and decoding Base64 documents.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "tiny-worker": "2.1.1",
     "wish-core-api": "0.4.0-beta-4",
     "wish-rpc": "0.6.5",
-    "ws": "2.3.1"
+    "ws": "2.3.1",
+    "base64-js": "1.3.0"
   },
   "bin": {
     "wish-cli": "./bin/cli"

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,6 +2,8 @@ var WishApp = require('wish-core-api').WishApp;
 var inspect = require("util").inspect;
 var bson = require('bson-buffer');
 var BSON = new bson();
+var Base64 = require('base64-js')
+
 
 var Directory = require('../deps/directory/directory.js').Directory;
 
@@ -140,6 +142,7 @@ function Cli() {
                 
                 repl.context.BSON = BSON;
                 repl.context.directory = new Directory(repl, printResult, Core);
+                repl.context.Base64 = Base64
             }
 
             syncctx();


### PR DESCRIPTION
This feature is useful when testing, for example you can easily encode a
certificate as Base64 and paste it into another wish-cli session and
decode it, and use the certificate.

Here is how you use it:

wish> Base64.fromByteArray(BSON.serialize({ cool: true }))
'DAAAAAhjb29sAAEA'

wish> BSON.deserialize(new Buffer(Base64.toByteArray('DAAAAAhjb29sAAEA')))
{ cool: true }